### PR TITLE
Feature & Fixes:  non-ASCII fix, and a custom-voice library, paste fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v1.2.0
+
+### Highlights
+
+**Named custom voice library.** Add multiple custom ElevenLabs voices, each with its own name, straight from the menu bar — they now appear as regular entries in the **Voice** menu instead of a single overwritable slot. A new "Add Custom Voice…" dialog takes a name and a voice ID, and a "Remove Custom Voice" submenu manages them. Voices are stored in `~/.config/speak11/custom_voices.json`.
+
+**Non-ASCII text fixed.** Selections containing German (ß, ä, ö, ü), accents, or other non-ASCII characters are now spoken correctly. When launched from the menu bar, the app had no `LANG` set, so `pbpaste` fell back to ASCII and the characters were mangled and then stripped before reaching ElevenLabs. Speak11 now forces a UTF-8 character type for the clipboard read.
+
+### New features
+
+- **Multiple named custom voices**: add, select, and remove custom ElevenLabs voices from the **Voice** menu; persisted to `custom_voices.json`
+
+### Bug fixes
+
+- **Paste in dialogs**: `⌘V` (and `⌘C`/`⌘X`/`⌘A`) now work in the Add Custom Voice, Sentence Pause, and API Key dialogs. The menu bar app has no Edit menu, so a new `EditableTextField` routes the standard editing shortcuts through the responder chain — previously only right-click → Paste worked.
+- **German / non-ASCII selections dropped**: force a UTF-8 `LC_CTYPE` in `speak.sh`, and pass `LC_CTYPE=UTF-8` to the spawned process from the app, so `pbpaste` keeps non-ASCII text intact
+
 ## v1.1.0
 
 ### Highlights

--- a/Speak11.swift
+++ b/Speak11.swift
@@ -448,8 +448,11 @@ private let hotkeyCallback: CGEventTapCallBack = { _, type, event, _ in
             let task = Process()
             task.executableURL = URL(fileURLWithPath: "/bin/bash")
             task.arguments    = [speakPath]
+            // Force a UTF-8 character type so speak.sh's pbpaste keeps non-ASCII
+            // text (ß, umlauts, accents, CJK). GUI-launched apps often have no
+            // LANG, which would make pbpaste fall back to ASCII and drop them.
             task.environment  = ProcessInfo.processInfo.environment.merging(
-                ["SPEAK11_MUTE_CHECKED": "1"]) { _, new in new }
+                ["SPEAK11_MUTE_CHECKED": "1", "LC_CTYPE": "UTF-8"]) { _, new in new }
 
             if let text = text {
                 let pipe = Pipe()

--- a/Speak11.swift
+++ b/Speak11.swift
@@ -31,8 +31,17 @@ final class EditableTextField: NSTextField {
 private let configDir  = (NSHomeDirectory() as NSString).appendingPathComponent(".config/speak11")
 private let configPath = (configDir as NSString).appendingPathComponent("config")
 private let speakPath  = (NSHomeDirectory() as NSString).appendingPathComponent(".local/bin/speak.sh")
+// User-defined ElevenLabs voices live in their own JSON file (not the
+// bash-sourced `config`) so arbitrary names never need shell escaping.
+private let customVoicesPath = (configDir as NSString).appendingPathComponent("custom_voices.json")
 
 // MARK: - Config model
+
+/// A user-added ElevenLabs voice (a display name + voice ID).
+struct CustomVoice: Codable {
+    var name: String
+    var id: String
+}
 
 struct Config {
     // Backend selection
@@ -41,6 +50,7 @@ struct Config {
 
     // ElevenLabs settings
     var voiceId:         String = "pFZP5JQG7iQjIQuC4Bku"
+    var customVoices:    [CustomVoice] = []
     var modelId:         String = "eleven_flash_v2_5"
     var stability:       Double = 0.5
     var similarityBoost: Double = 0.75
@@ -89,6 +99,11 @@ struct Config {
             default: break
             }
         }
+        // Custom voices live in a separate JSON file.
+        if let data = FileManager.default.contents(atPath: customVoicesPath),
+           let voices = try? JSONDecoder().decode([CustomVoice].self, from: data) {
+            c.customVoices = voices
+        }
         return c
     }
 
@@ -111,6 +126,11 @@ struct Config {
         ]
         try? (lines.joined(separator: "\n") + "\n")
             .write(toFile: configPath, atomically: true, encoding: .utf8)
+
+        // Persist custom voices to their own JSON file.
+        if let data = try? JSONEncoder().encode(customVoices) {
+            try? data.write(to: URL(fileURLWithPath: customVoicesPath), options: .atomic)
+        }
     }
 }
 
@@ -823,14 +843,41 @@ private let hotkeyCallback: CGEventTapCallBack = { _, type, event, _ in
     }
 
     private func buildVoiceItems() -> [NSMenuItem] {
-        let isCustom = !knownVoices.contains { $0.id == config.voiceId }
         var items = knownVoices.map { v in
             item(v.name, #selector(pickVoice(_:)), repr: v.id, on: v.id == config.voiceId)
         }
+
+        // User-added custom voices — selectable like presets (reuse pickVoice).
+        if !config.customVoices.isEmpty {
+            items.append(.separator())
+            for v in config.customVoices {
+                items.append(item(v.name, #selector(pickVoice(_:)),
+                                  repr: v.id, on: v.id == config.voiceId))
+            }
+        }
+
+        // An active voice that is neither a preset nor a saved custom voice
+        // (e.g. set via the ELEVENLABS_VOICE_ID env var or an older config).
+        let isKnown = knownVoices.contains       { $0.id == config.voiceId }
+        let isSaved = config.customVoices.contains { $0.id == config.voiceId }
+        if !isKnown && !isSaved {
+            items.append(.separator())
+            items.append(item("Custom: \(config.voiceId)", #selector(pickVoice(_:)),
+                              repr: config.voiceId, on: true))
+        }
+
         items.append(.separator())
-        let customLabel = isCustom ? "Custom: \(config.voiceId)" : "Custom voice ID…"
-        items.append(item(customLabel, #selector(customVoice), repr: "", on: isCustom))
+        items.append(item("Add Custom Voice\u{2026}", #selector(addCustomVoice), repr: "", on: false))
+        if !config.customVoices.isEmpty {
+            items.append(submenuItem("Remove Custom Voice", items: buildRemoveCustomVoiceItems()))
+        }
         return items
+    }
+
+    private func buildRemoveCustomVoiceItems() -> [NSMenuItem] {
+        config.customVoices.map { v in
+            item(v.name, #selector(removeCustomVoice(_:)), repr: v.id, on: false)
+        }
     }
 
     private func buildLocalVoiceItems() -> [NSMenuItem] {
@@ -1085,24 +1132,54 @@ private let hotkeyCallback: CGEventTapCallBack = { _, type, event, _ in
         scheduleRespeak()
     }
 
-    @objc private func customVoice() {
+    @objc private func addCustomVoice() {
         NSApp.setActivationPolicy(.regular)
         defer { NSApp.setActivationPolicy(.accessory) }
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
-        alert.messageText = "Custom Voice ID"
-        alert.informativeText = "Enter a voice ID from elevenlabs.io/voice-library"
+        alert.messageText = "Add Custom Voice"
+        alert.informativeText = "Enter a name and a voice ID from elevenlabs.io/voice-library."
         alert.addButton(withTitle: "Save")
         alert.addButton(withTitle: "Cancel")
-        let field = EditableTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 22))
-        field.stringValue = config.voiceId
-        field.placeholderString = "e.g. pFZP5JQG7iQjIQuC4Bku"
-        alert.accessoryView = field
-        alert.window.initialFirstResponder = field
+
+        // Two stacked fields (name on top, ID below). EditableTextField so ⌘V works.
+        let nameField = EditableTextField(frame: NSRect(x: 0, y: 30, width: 320, height: 22))
+        nameField.placeholderString = "Name (e.g. Antoni)"
+        let idField = EditableTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 22))
+        idField.placeholderString = "Voice ID (e.g. pFZP5JQG7iQjIQuC4Bku)"
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 320, height: 52))
+        container.addSubview(nameField)
+        container.addSubview(idField)
+        nameField.nextKeyView = idField
+        alert.accessoryView = container
+        alert.window.initialFirstResponder = nameField
+
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        let val = field.stringValue.trimmingCharacters(in: .whitespaces)
-        guard !val.isEmpty else { return }
-        config.voiceId = val
+        let id = idField.stringValue.trimmingCharacters(in: .whitespaces)
+        guard !id.isEmpty else { return }
+        var name = nameField.stringValue.trimmingCharacters(in: .whitespaces)
+        if name.isEmpty { name = id }
+
+        // Update the name if this ID already exists, otherwise append.
+        if let idx = config.customVoices.firstIndex(where: { $0.id == id }) {
+            config.customVoices[idx].name = name
+        } else {
+            config.customVoices.append(CustomVoice(name: name, id: id))
+        }
+        config.voiceId = id
+        config.save()
+        rebuildMenu()
+        scheduleRespeak()
+    }
+
+    @objc private func removeCustomVoice(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? String else { return }
+        config.customVoices.removeAll { $0.id == id }
+        // If the removed voice was active, fall back to the default preset.
+        if config.voiceId == id {
+            config.voiceId = knownVoices.first?.id ?? "pFZP5JQG7iQjIQuC4Bku"
+        }
         config.save()
         rebuildMenu()
         scheduleRespeak()

--- a/Speak11.swift
+++ b/Speak11.swift
@@ -2,6 +2,30 @@ import Cocoa
 import ApplicationServices
 import CoreAudio
 
+// MARK: - Editable text field
+//
+// This app runs as an accessory (LSUIElement) with no main menu, so there is
+// no Edit menu to provide the standard ⌘X/⌘C/⌘V/⌘A key equivalents. Without
+// them, text fields in our NSAlert dialogs only support paste via right-click.
+// Routing the editing actions to the field editor through the responder chain
+// restores the expected keyboard shortcuts regardless of activation policy.
+final class EditableTextField: NSTextField {
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.type == .keyDown,
+           event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command {
+            switch event.charactersIgnoringModifiers {
+            case "x": if NSApp.sendAction(#selector(NSText.cut(_:)),    to: nil, from: self) { return true }
+            case "c": if NSApp.sendAction(#selector(NSText.copy(_:)),   to: nil, from: self) { return true }
+            case "v": if NSApp.sendAction(#selector(NSText.paste(_:)),  to: nil, from: self) { return true }
+            case "a": if NSApp.sendAction(#selector(NSResponder.selectAll(_:)), to: nil, from: self) { return true }
+            case "z": if NSApp.sendAction(Selector(("undo:")),          to: nil, from: self) { return true }
+            default: break
+            }
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+}
+
 // MARK: - Config paths
 
 private let configDir  = (NSHomeDirectory() as NSString).appendingPathComponent(".config/speak11")
@@ -1067,7 +1091,7 @@ private let hotkeyCallback: CGEventTapCallBack = { _, type, event, _ in
         alert.informativeText = "Enter a voice ID from elevenlabs.io/voice-library"
         alert.addButton(withTitle: "Save")
         alert.addButton(withTitle: "Cancel")
-        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 22))
+        let field = EditableTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 22))
         field.stringValue = config.voiceId
         field.placeholderString = "e.g. pFZP5JQG7iQjIQuC4Bku"
         alert.accessoryView = field
@@ -1116,7 +1140,7 @@ private let hotkeyCallback: CGEventTapCallBack = { _, type, event, _ in
         alert.informativeText = "Milliseconds of silence between sentences (at 1\u{00D7} speed). Set to 0 for no pause."
         alert.addButton(withTitle: "Save")
         alert.addButton(withTitle: "Cancel")
-        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 22))
+        let field = EditableTextField(frame: NSRect(x: 0, y: 0, width: 120, height: 22))
         field.stringValue = String(config.sentencePause)
         field.placeholderString = "e.g. 400"
         alert.accessoryView = field
@@ -1288,7 +1312,7 @@ private let hotkeyCallback: CGEventTapCallBack = { _, type, event, _ in
                 alert.addButton(withTitle: "Remove")
             }
 
-            let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 22))
+            let field = EditableTextField(frame: NSRect(x: 0, y: 0, width: 320, height: 22))
             if errorMessage == nil, let key = existingKey {
                 if key.count > 8 {
                     let start = key.prefix(4)

--- a/speak.sh
+++ b/speak.sh
@@ -10,6 +10,15 @@
 # Requirements: afplay (built into macOS), curl (for ElevenLabs),
 #   venv python at ~/.local/share/speak11/venv (installed by install.command)
 
+# ── Character encoding ─────────────────────────────────────────────
+# pbpaste (and other tools) emit the standard C/ASCII encoding when no UTF-8
+# locale is set, which silently drops non-ASCII text (ß, umlauts, accents,
+# CJK). GUI-launched apps often have no LANG, so force a UTF-8 character type
+# for the whole pipeline. Only the encoding is changed (region-neutral); any
+# existing UTF-8 locale is left untouched.
+case "${LC_ALL:-}"   in C|POSIX) unset LC_ALL ;; esac
+case "${LC_CTYPE:-}" in ""|C|POSIX) export LC_CTYPE="UTF-8" ;; esac
+
 # ── Configuration ──────────────────────────────────────────────────
 
 # Save env vars before sourcing config (source overwrites same-named vars).

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1943,6 +1943,18 @@ check "tts_server.py: cleans up speak11_tts_ temp dirs on startup" \
 
 section "Unicode sanitization"
 
+# pbpaste drops non-ASCII (ß, umlauts, accents) under the C/ASCII encoding that
+# GUI-launched apps get when no LANG is set. speak.sh forces a UTF-8 ctype, and
+# the app passes LC_CTYPE=UTF-8 to the child process.
+check "speak.sh: forces a UTF-8 LC_CTYPE for pbpaste" \
+    "yes" "$(grep -q 'LC_CTYPE="UTF-8"' "$SPEAK_SH" && echo "yes" || echo "no")"
+
+check "speak.sh: UTF-8 ctype set before reading the clipboard" \
+    "yes" "$(awk '/LC_CTYPE="UTF-8"/{c=NR} /Read selected text/{r=NR} END{print (c && r && c<r) ? "yes" : "no"}' "$SPEAK_SH")"
+
+check "Speak11.swift: passes LC_CTYPE=UTF-8 to speak.sh" \
+    "yes" "$(grep -q '"LC_CTYPE": "UTF-8"' "$SCRIPT_DIR/Speak11.swift" && echo "yes" || echo "no")"
+
 check "speak.sh: sanitizes text with iconv before TTS" \
     "yes" "$(grep -q 'iconv -f UTF-8 -t UTF-8//IGNORE' "$SPEAK_SH" && echo "yes" || echo "no")"
 
@@ -4514,6 +4526,17 @@ if type normalize_text &>/dev/null; then
     check "normalize: forests joins (inflected form)" \
         "forests" "$(normalize_text $'for-\nests')"
 
+    # Non-ASCII preservation: ElevenLabs supports many languages, so the
+    # normalizer must never strip German (ß, umlauts) or other accented text.
+    check "normalize: preserves German eszett and umlauts" \
+        "Das Maß für Größe und Spaß." "$(normalize_text 'Das Maß für Größe und Spaß.')"
+
+    check "normalize: preserves uppercase umlauts" \
+        "Über Öl und Äpfel." "$(normalize_text 'Über Öl und Äpfel.')"
+
+    check "normalize: preserves accented Latin text" \
+        "café résumé naïve Zürich" "$(normalize_text 'café résumé naïve Zürich')"
+
     # Line break rejoining
     check "normalize: rejoin mid-sentence line break" \
         "The quick brown fox jumped." "$(normalize_text $'The quick brown\nfox jumped.')"
@@ -5669,6 +5692,10 @@ if type normalize_text &>/dev/null; then
         "where alpha equals 5" \
         "$(normalize_text 'where $\alpha = 5$')"
 
+    check "latex: preserves German text around math" \
+        "Die Größe ist alpha equals 5 für Müller." \
+        "$(normalize_text 'Die Größe ist $\alpha = 5$ für Müller.')"
+
     check "latex: plain text not detected as LaTeX" \
         "The quick brown fox jumped." \
         "$(normalize_text 'The quick brown fox jumped.')"
@@ -6071,6 +6098,11 @@ Hello.')"
         "Title: Introduction. This is important." \
         "$(normalize_text '# Introduction
 This is **important**.')"
+
+    check "markdown: preserves German heading + bold" \
+        "Title: Größe. Das Maß für Spaß und Müller." \
+        "$(normalize_text '# Größe
+Das Maß für **Spaß** und Müller.')"
 
     check "markdown: plain text not detected as Markdown" \
         "Just a normal sentence." \

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4229,12 +4229,25 @@ check "Speak11.swift: passes SPEAK11_MUTE_CHECKED to speak.sh" \
 check "speak.sh: skips mute check when SPEAK11_MUTE_CHECKED=1" \
     "yes" "$(grep -q 'SPEAK11_MUTE_CHECKED' "$SPEAK_SH" && echo "yes" || echo "no")"
 
-# Cmd+V paste support: dialogs with text fields must use .regular activation policy
-check "Speak11.swift: API key dialog enables paste (regular activation)" \
-    "yes" "$(awk '/func showAPIKeyDialog/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'setActivationPolicy(.regular)' && echo "yes" || echo "no")"
+# Cmd+V paste support: the app has no Edit menu (accessory app), so dialog text
+# fields use EditableTextField, which routes ⌘X/⌘C/⌘V/⌘A through the responder chain.
+check "Speak11.swift: EditableTextField subclass exists" \
+    "yes" "$(grep -q 'class EditableTextField: NSTextField' "$SCRIPT_DIR/Speak11.swift" && echo "yes" || echo "no")"
 
-check "Speak11.swift: custom voice dialog enables paste (regular activation)" \
-    "yes" "$(awk '/func customVoice/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'setActivationPolicy(.regular)' && echo "yes" || echo "no")"
+check "Speak11.swift: EditableTextField overrides performKeyEquivalent" \
+    "yes" "$(awk '/class EditableTextField/,/^}/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'performKeyEquivalent' && echo "yes" || echo "no")"
+
+check "Speak11.swift: EditableTextField handles paste" \
+    "yes" "$(awk '/class EditableTextField/,/^}/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'NSText.paste' && echo "yes" || echo "no")"
+
+check "Speak11.swift: API key dialog uses EditableTextField for paste" \
+    "yes" "$(awk '/func showAPIKeyDialog/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'EditableTextField' && echo "yes" || echo "no")"
+
+check "Speak11.swift: sentence pause dialog uses EditableTextField for paste" \
+    "yes" "$(awk '/func editSentencePause/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'EditableTextField' && echo "yes" || echo "no")"
+
+check "Speak11.swift: custom voice dialog uses EditableTextField for paste" \
+    "yes" "$(awk '/func customVoice/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'EditableTextField' && echo "yes" || echo "no")"
 
 check "Speak11.swift: dialogs restore accessory policy via defer" \
     "yes" "$(grep -c 'defer.*setActivationPolicy(.accessory)' "$SCRIPT_DIR/Speak11.swift" | awk '{print ($1 >= 2) ? "yes" : "no"}')"
@@ -4417,7 +4430,7 @@ check "Speak11.swift: Sentence Pause menu item shows current value" \
     "yes" "$(grep -q 'Sentence Pause.*sentencePause' "$SETTINGS_SWIFT" && echo "yes" || echo "no")"
 
 check "Speak11.swift: Sentence Pause uses text input dialog" \
-    "yes" "$(awk '/func editSentencePause/,/^    \}/' "$SETTINGS_SWIFT" | grep -q 'NSTextField' && echo "yes" || echo "no")"
+    "yes" "$(awk '/func editSentencePause/,/^    \}/' "$SETTINGS_SWIFT" | grep -q 'EditableTextField' && echo "yes" || echo "no")"
 
 # speak11-audio.swift: pause_ms field in protocol
 check "speak11-audio.swift: maxSplits is 5 (6 fields)" \

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -4258,11 +4258,36 @@ check "Speak11.swift: API key dialog uses EditableTextField for paste" \
 check "Speak11.swift: sentence pause dialog uses EditableTextField for paste" \
     "yes" "$(awk '/func editSentencePause/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'EditableTextField' && echo "yes" || echo "no")"
 
-check "Speak11.swift: custom voice dialog uses EditableTextField for paste" \
-    "yes" "$(awk '/func customVoice/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'EditableTextField' && echo "yes" || echo "no")"
+check "Speak11.swift: add custom voice dialog uses EditableTextField for paste" \
+    "yes" "$(awk '/func addCustomVoice/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'EditableTextField' && echo "yes" || echo "no")"
 
 check "Speak11.swift: dialogs restore accessory policy via defer" \
     "yes" "$(grep -c 'defer.*setActivationPolicy(.accessory)' "$SCRIPT_DIR/Speak11.swift" | awk '{print ($1 >= 2) ? "yes" : "no"}')"
+
+# Multiple named custom voices
+check "Speak11.swift: CustomVoice model exists" \
+    "yes" "$(grep -q 'struct CustomVoice' "$SCRIPT_DIR/Speak11.swift" && echo "yes" || echo "no")"
+
+check "Speak11.swift: Config stores customVoices" \
+    "yes" "$(grep -q 'var customVoices' "$SCRIPT_DIR/Speak11.swift" && echo "yes" || echo "no")"
+
+check "Speak11.swift: persists custom voices to JSON" \
+    "yes" "$(grep -q 'custom_voices.json' "$SCRIPT_DIR/Speak11.swift" && echo "yes" || echo "no")"
+
+check "Speak11.swift: addCustomVoice function exists" \
+    "yes" "$(grep -q 'func addCustomVoice' "$SCRIPT_DIR/Speak11.swift" && echo "yes" || echo "no")"
+
+check "Speak11.swift: removeCustomVoice function exists" \
+    "yes" "$(grep -q 'func removeCustomVoice' "$SCRIPT_DIR/Speak11.swift" && echo "yes" || echo "no")"
+
+check "Speak11.swift: custom voices appear in the Voice menu" \
+    "yes" "$(awk '/func buildVoiceItems/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'customVoices' && echo "yes" || echo "no")"
+
+check "Speak11.swift: custom voices reuse pickVoice selector" \
+    "yes" "$(awk '/func buildVoiceItems/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'pickVoice' && echo "yes" || echo "no")"
+
+check "Speak11.swift: addCustomVoice calls scheduleRespeak" \
+    "yes" "$(awk '/func addCustomVoice/,/^    }/' "$SCRIPT_DIR/Speak11.swift" | grep -q 'scheduleRespeak' && echo "yes" || echo "no")"
 
 # API key validation
 check "Speak11.swift: validateAPIKey function exists" \


### PR DESCRIPTION
Fixes #4 #2 #1 

Three independent changes, one commit each (+ a changelog commit).

- **German/accents dropped on ElevenLabs (fix).** `pbpaste` falls back to ASCII when the GUI app runs with no `LANG`, mangling ß/ä/ö/ü (then stripped by `iconv`). Now `speak.sh` forces a UTF-8 `LC_CTYPE` and the app passes `LC_CTYPE=UTF-8` to the child. The normalizer was never at fault.
- **Named custom voices (feature).** Add/select/remove multiple custom ElevenLabs voices from the Voice menu (name + ID), persisted to `~/.config/speak11/custom_voices.json` — replacing the single overwritable slot.
- **`⌘V` paste in dialogs (fix).** The accessory app has no Edit menu, so paste/copy/cut/select-all had no key equivalents. Added an `EditableTextField` subclass that routes them through the responder chain; used in the Custom Voice, Sentence Pause, and API Key dialogs.

**Verification:** `swiftc` builds clean; `bash tests/test.sh` → 1098 passed, 3 failed (pre-existing `mlx-audio` tests absent from this machine, unrelated). 24 new/updated assertions + an end-to-end clipboard check of the encoding fix.

## Demo images

<img width="379" height="295" alt="Screenshot 2026-06-04 at 12 51 01" src="https://github.com/user-attachments/assets/c1288fac-da21-4ae2-837a-394b57aa197a" />
<img width="387" height="191" alt="Screenshot 2026-06-04 at 12 52 39" src="https://github.com/user-attachments/assets/833c1614-c993-4dfe-ac28-73d838694747" /> 
<br/> 

