### PR TITLE
Restrict Python version check to 3.10-3.12

### DIFF
--- a/install-local.sh
+++ b/install-local.sh
@@ -40,7 +40,7 @@ find_python() {
         p=$(command -v "$py" 2>/dev/null || echo "$py")
         [ -x "$p" ] || continue
         local ver
-        ver=$("$p" -c "import sys; print(sys.version_info >= (3,10))" 2>/dev/null) || continue
+        ver=$("$p" -c "import sys; print(sys.version_info >= (3,10) and sys.version_info < (3,13))" 2>/dev/null) || continue
         if [ "$ver" = "True" ]; then
             echo "$p"
             return 0


### PR DESCRIPTION
find_python accepts any Python >= 3.10 with no upper bound, so on a system with Homebrew Python 3.14 it selects 3.14. Kokoro's dependency misaki caps at Requires-Python <3.13, so pip fails with "No matching distribution found for misaki==0.8.4" and the install aborts. Because runInstallLocal in Speak11.swift discards stdout/stderr and shows a generic message, the user sees "An internet connection is required" instead of the real error (see issue #3). This adds an upper bound (<3.13) to the version check in find_python and the cached check in download_python, so a too-new system Python is skipped and the bundled standalone 3.12 is used instead. Tested on macOS 26.4 / M5-series: install now completes and the Kokoro model downloads.

Fixes #3