### PR TITLE
Fix #4: preserve accented/non-ASCII characters (UTF-8 locale)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- **Accented / non-ASCII characters preserved end-to-end** (#4): the menu bar app is launched by launchd with no locale set, so `pbpaste` and the Python helpers fell back to ASCII and stripped or transliterated diacritics (e.g. "Perché" → "Perch", "Zażółć" → "zazolc") before the text reached ElevenLabs. `speak.sh` now forces a UTF-8 locale (keeping an existing UTF-8 one), `normalize.py` and the inline sentence splitter reconfigure stdio to UTF-8 regardless of locale, and the Swift launcher exports `LC_ALL`/`LANG` to the speak.sh subprocess.
+
 ## v1.1.0
 
 ### Highlights

--- a/Speak11.swift
+++ b/Speak11.swift
@@ -424,8 +424,19 @@ private let hotkeyCallback: CGEventTapCallBack = { _, type, event, _ in
             let task = Process()
             task.executableURL = URL(fileURLWithPath: "/bin/bash")
             task.arguments    = [speakPath]
+            // GUI apps launched via launchd inherit no locale, which makes
+            // pbpaste and Python strip accented characters (issue #4).
+            // Force UTF-8 unless the user already has a UTF-8 locale.
             task.environment  = ProcessInfo.processInfo.environment.merging(
                 ["SPEAK11_MUTE_CHECKED": "1"]) { _, new in new }
+            let inheritedLocale = task.environment?["LC_ALL"]
+                ?? task.environment?["LC_CTYPE"]
+                ?? task.environment?["LANG"] ?? ""
+            if !inheritedLocale.uppercased().contains("UTF-8")
+                && !inheritedLocale.uppercased().contains("UTF8") {
+                task.environment?["LC_ALL"] = "en_US.UTF-8"
+                task.environment?["LANG"]   = "en_US.UTF-8"
+            }
 
             if let text = text {
                 let pipe = Pipe()

--- a/normalize.py
+++ b/normalize.py
@@ -7,6 +7,15 @@ The back-end never knows the source.
 """
 import re, sys, unicodedata as _ud, ftfy
 
+# Force UTF-8 stdio regardless of the inherited locale. GUI apps launched
+# via launchd carry no LANG/LC_*, so Python would otherwise decode stdin /
+# encode stdout as ASCII and mangle accented characters (issue #4).
+try:
+    sys.stdin.reconfigure(encoding="utf-8")
+    sys.stdout.reconfigure(encoding="utf-8")
+except (AttributeError, ValueError):
+    pass
+
 # ── Shared data (used by front-ends and back-end) ────────────────
 
 _SD = str.maketrans(

--- a/speak.sh
+++ b/speak.sh
@@ -10,6 +10,17 @@
 # Requirements: afplay (built into macOS), curl (for ElevenLabs),
 #   venv python at ~/.local/share/speak11/venv (installed by install.command)
 
+# ── Force a UTF-8 locale ────────────────────────────────────────────
+# GUI apps launched via launchd inherit no locale (LANG/LC_* unset), so
+# `pbpaste` and Python default to ASCII and strip or transliterate
+# accented characters before the text reaches the TTS API (issue #4).
+# Keep an existing UTF-8 locale; otherwise force one so the whole
+# pipeline — clipboard read, text cleanup, sentence split — stays UTF-8.
+case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *.UTF-8|*.utf-8|*.UTF8|*.utf8) ;;        # already UTF-8 — leave it
+    *) export LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8" ;;
+esac
+
 # ── Configuration ──────────────────────────────────────────────────
 
 # Save env vars before sourcing config (source overwrites same-named vars).
@@ -216,6 +227,11 @@ _trace() {
 split_sentences() {
     [ -x "$VENV_PYTHON" ] && "$VENV_PYTHON" -c "
 import re, sys
+try:
+    sys.stdin.reconfigure(encoding='utf-8')
+    sys.stdout.reconfigure(encoding='utf-8')
+except (AttributeError, ValueError):
+    pass
 text = sys.stdin.read().rstrip('\n')
 try:
     import pysbd


### PR DESCRIPTION
## Summary

Fixes #4. Accented / non-ASCII characters (Polish, Italian, etc.) were stripped or replaced before the text reached ElevenLabs, so they were mispronounced.

## Root cause

The menu bar app is launched by launchd, which gives it an environment with **no `LANG`/`LC_*` set**. The hotkey handler simulates ⌘C and then runs `speak.sh` with no argument, so `speak.sh` reads the selection via `pbpaste`. Under the resulting C/POSIX locale, **`pbpaste` replaces every non-ASCII character with `?`** (and a non‑UTF‑8 venv Python would likewise mangle stdin/stdout).

Reproduction on macOS:

```console
$ printf '%s' 'Perché città Zażółć' | pbcopy
$ pbpaste                 # normal shell — LANG is set
Perché città Zażółć
$ env -i pbpaste          # launchd-like — no locale
Perch? citt? Za????
```

The JSON encoding (`json_encode` + `curl`) and the `iconv` step are byte-safe and were **not** the problem; ElevenLabs accepts UTF-8 JSON and pronounces the diacritics correctly when they actually arrive.

## Fix

- **`speak.sh`** exports a UTF-8 locale at the top — before any `pbpaste`/Python call — keeping an existing UTF-8 locale if the user already has one. This is the load-bearing fix.
- **`normalize.py`** and the inline `split_sentences` Python reconfigure stdin/stdout to UTF-8 regardless of locale, so the pipeline is safe even on setups where Python defaults to ASCII (and where `en_US.UTF-8` is missing).
- **`Speak11.swift`** exports `LC_ALL`/`LANG` to the `speak.sh` subprocess as an extra safeguard.

## Verification

- `env -i pbpaste` after applying the locale logic now returns the full `Perché città Zażółć`.
- End-to-end: selecting accented text and pressing ⌥⇧/ is now pronounced correctly.
- `normalize.py` preserves Italian and Polish diacritics across the PDF, LaTeX, and Markdown front-ends, including with stdio forced to ASCII (`PYTHONIOENCODING=ascii`); output is identical to the UTF-8-locale run.
- Existing `tests/test.sh` "Unicode sanitization" section: 8/8 pass.